### PR TITLE
Update security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,33 +5,44 @@
 We are currently providing security updates to the following http4s core versions: 
 
 | Version | Supported          |
-| ------- | ------------------ |
-| 0.21.x   | :white_check_mark: |
-| 0.20.x   | :white_check_mark: |
-| 0.19.x   | :x: |
-| 0.18.x   | :x: |
-| < 0.18   | :x: |
+|---------|--------------------|
+| 1.x     | :white_check_mark: |
+| 0.23.x  | :white_check_mark: |
+| 0.22.x  | :x:                |
+| 0.21.x  | :x:                |
+| 0.20.x  | :x:                |
+| 0.19.x  | :x:                |
+| 0.18.x  | :x:                |
+| < 0.18  | :x:                |
 
 For other repos in the http4s org on different release cycles, see their documentation.
 
-## Reporting a Vulnerability
+## Reporting a Security Issue
 
-We will use [keybase](https://keybase.io) as the vehicle for reporting security issues as that gives us a
-forum to discuss, analyze, and remediate the threat before an exploit is published.
-[Responsible disclosure](https://en.wikipedia.org/wiki/Responsible_disclosure) enhances security for the entire community.
+To report a security issue, please use one of the following methods:
 
-If the issue is deemed a vulnerability, we will release a patch version of our software
-and make sure that finds it way to Maven Central before we push the patch to github.
-After the patch is available on Maven Central, we will also provide a [security advisory](https://github.com/http4s/http4s/security/advisories) through github.
-As with every release, the source jars are published to maven central at the same time as the binaries.
+1. Navigate to the "Security and quality" tab at the top of the relevant repository, click the "Report a vulnerability" button, and complete the form as much as possible.
+2. Email the [Security Team](#security-team) with a description of the issue, the steps you took to create the issue, affected versions, and, if known, mitigations for the issue.
 
-We strongly recommend users of our libraries to use [Scala Steward](https://github.com/fthomas/scala-steward) or something similar to 
+The Security Team will attempt to respond within 3 working days of your report.  If the issue is confirmed as a vulnerability, we will open a Security Advisory.  This project follows a 90 day disclosure timeline.
+
+## Procedure
+
+1. A GitHub Security Advisory will be created in the appropriate repository.
+2. A project member works privately with the reporter to resolve the vulnerability.
+3. The project creates a new release of the package the vulnerabilty affects to deliver its fix.
+4. The project publicly announces the vulnerability and describes how to apply the fix.
+
+## Scala Steward
+
+We strongly recommend users of our libraries to use [Scala Steward](https://github.com/scala-steward-org/scala-steward) or something similar to 
 automatically receive updates.
 
 ### Security Maintainer list:
 
-|name | github | keybase |
-|-----|--------|---------|
-| Ross A. Baker | @rossabaker | @rossabaker|
-| Christopher Davenport | @christopherdavenport | @davenpcm |
-| Erlend Hamnaberg | @hamnis | @hamnis|  
+| name                                           | email               | PGP public key                                                                                                         |
+|------------------------------------------------|---------------------|------------------------------------------------------------------------------------------------------------------------|
+| [Ross A. Baker](https://github.com/rossabaker) | ross@rossabaker.com | [0x975BE5BC29D92CA5](https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x904c153733dbb0106915c0bd975be5bc29d92ca5) |
+| [Arman Bilge](https://github.com/armanbilge)   | arman@typelevel.org | [0xA335B107E9282548](https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x1CAE49948EE0A2D7154A2B62A335B107E9282548) |
+| [Erlend Hamnaberg](https://github.com/hamnis)  |                     |
+||


### PR DESCRIPTION
- Refreshes core version numbers
- Mostly copies Typelevel's after it was recently refurbished
- Drops Keybase, which I don't think anyone uses anymore.  I don't.